### PR TITLE
Fix for /man/ width issue

### DIFF
--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -107,7 +107,7 @@ code {
   @apply p-1 rounded whitespace-pre select-all;
 }
 pre  {
-  @apply rounded p-5 my-5 overflow-x-scroll max-w-min;
+  @apply rounded p-5 my-5 overflow-x-scroll;
 }
 pre, code {
    @apply bg-gray-200 dark:text-gray-900;


### PR DESCRIPTION
Removed `max-width: min-content;` from `pre`, which was causing the man page to have a small width.