### PR TITLE
Correct release date in v2.10.md release notes post

### DIFF
--- a/site/blog/2022/v2.10.md
+++ b/site/blog/2022/v2.10.md
@@ -1,11 +1,11 @@
 ---
 title: v2.10
-date: 2022-09-29
+date: 2022-08-28
 tags:
     - releases
 ---
 
-## [v2.10](https://github.com/saulpw/visidata/releases/tag/v2.10) (2022-09-29)
+## [v2.10](https://github.com/saulpw/visidata/releases/tag/v2.10) (2022-08-28)
 
 
 ### VisiData v2.10: Autoload installed plugins


### PR DESCRIPTION
Corrected release date to actual release date of August 28, as shown here: https://github.com/saulpw/visidata/releases/tag/v2.10